### PR TITLE
[android] remove MIMETYPE_TEXT_PLAIN check

### DIFF
--- a/src/android/Clipboard.java
+++ b/src/android/Clipboard.java
@@ -37,10 +37,6 @@ public class Clipboard extends CordovaPlugin {
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, e.toString()));
             }
         } else if (action.equals(actionPaste)) {
-            if (!clipboard.getPrimaryClipDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
-                callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.NO_RESULT));
-            }
-
             try {
                 ClipData.Item item = clipboard.getPrimaryClip().getItemAt(0);
                 String text = item.getText().toString();


### PR DESCRIPTION
This is more like a question instead of a PR.

Can we safely remove this check?

Indeed, it makes copy/pasting from HTML emails to work.
